### PR TITLE
refactor: API routes

### DIFF
--- a/src/services/fastapi/db.py
+++ b/src/services/fastapi/db.py
@@ -1,0 +1,8 @@
+import os
+
+from dotenv import load_dotenv
+from sqlmodel import create_engine
+
+load_dotenv()
+
+engine = create_engine(os.environ["DATABASE_URI"])

--- a/src/services/fastapi/main.py
+++ b/src/services/fastapi/main.py
@@ -1,136 +1,23 @@
-import json
-import os
-from enum import Enum
-
-from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import RedirectResponse, Response
-from sqlmodel import Session, create_engine, select
 
-from src.models import RiskGroup, Strategy, Vault, create_id
-
-load_dotenv()
-
-engine = create_engine(os.environ["DATABASE_URI"])
-
-app = FastAPI()
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+from src.services.fastapi.routes.api import router as api_router
 
 
-class Tags(Enum):
-    vaults = "Vaults"
-    strategies = "Strategies"
-    riskGroups = "Risk Groups"
+def get_application() -> FastAPI:
+    application = FastAPI()
+
+    application.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    application.include_router(api_router)
+
+    return application
 
 
-@app.get("/", include_in_schema=False)
-def root():
-    message = """
-
-    Welcome to Yearn Data Analytics!
-
-    The current endpoint for the risk framework API is /api,
-    which will automatically redirect you to the API documentation page.
-
-    """
-    return Response(content=message, media_type="text/plain")
-
-
-@app.get("/api", include_in_schema=False)
-def redirect_api_docs():
-    """Redirect to the OpenAPI documentation"""
-    return RedirectResponse("/docs")
-
-
-@app.get("/api/vaults", tags=[Tags.vaults])
-def get_all_vaults():
-    """Fetch vault-level risk metrics for all available vaults"""
-    with Session(engine) as session:
-        query = select(Vault)
-        vaults = session.exec(query).all()
-    return {vault.address: json.loads(vault.info) for vault in vaults}
-
-
-@app.get("/api/vaults/{chain_id}", tags=[Tags.vaults])
-def get_network_vaults(chain_id):
-    """Fetch vault-level risk metrics for a specific chain"""
-    with Session(engine) as session:
-        query = select(Vault).where(Vault.network == chain_id)
-        vaults = session.exec(query).all()
-    return {vault.address: json.loads(vault.info) for vault in vaults}
-
-
-@app.get("/api/vaults/{chain_id}/{address}", tags=[Tags.vaults])
-def get_vault(chain_id, address):
-    """Fetch vault-level risk metrics for a specific vault"""
-    with Session(engine) as session:
-        vault_id = create_id(address, chain_id)
-        vault = session.get(Vault, vault_id)
-    if vault is None:
-        raise HTTPException(status_code=404, detail="Address not found")
-    return json.loads(vault.info)
-
-
-@app.get("/api/strategies", tags=[Tags.strategies])
-def get_all_strategies():
-    """Fetch strategy-level risk metrics for all available strategies"""
-    with Session(engine) as session:
-        query = select(Strategy)
-        strategies = session.exec(query).all()
-    return {strategy.address: json.loads(strategy.info) for strategy in strategies}
-
-
-@app.get("/api/strategies/{chain_id}", tags=[Tags.strategies])
-def get_network_strategies(chain_id):
-    """Fetch strategy-level risk metrics for a specific chain"""
-    with Session(engine) as session:
-        query = select(Strategy).where(Strategy.network == chain_id)
-        strategies = session.exec(query).all()
-    return {strategy.address: json.loads(strategy.info) for strategy in strategies}
-
-
-@app.get("/api/strategies/{chain_id}/{address}", tags=[Tags.strategies])
-def get_strategy(chain_id, address):
-    """Fetch strategy-level risk metrics for a specific strategy"""
-    with Session(engine) as session:
-        strategy_id = create_id(address, chain_id)
-        strategy = session.get(Strategy, strategy_id)
-    if strategy is None:
-        raise HTTPException(status_code=404, detail="Address not found")
-    return json.loads(strategy.info)
-
-
-@app.get("/api/riskgroups", tags=[Tags.riskGroups])
-def get_all_risk_groups():
-    """Fetch all risk groups"""
-    with Session(engine) as session:
-        query = select(RiskGroup)
-        groups = session.exec(query).all()
-    return groups
-
-
-@app.get("/api/riskgroups/{chain_id}", tags=[Tags.riskGroups])
-def get_network_risk_groups(chain_id):
-    """Fetch risk groups for a specific chain"""
-    with Session(engine) as session:
-        query = select(RiskGroup).where(RiskGroup.network == chain_id)
-        groups = session.exec(query).all()
-    return groups
-
-
-@app.get("/api/riskgroups/{chain_id}/{group_id}", tags=[Tags.riskGroups])
-def get_risk_group(chain_id, group_id):
-    """Fetch a specific risk group"""
-    with Session(engine) as session:
-        group_id = create_id(group_id, chain_id)
-        group = session.get(RiskGroup, group_id)
-    if group is None:
-        raise HTTPException(status_code=404, detail="Group ID not found")
-    return group
+app = get_application()

--- a/src/services/fastapi/routes/api.py
+++ b/src/services/fastapi/routes/api.py
@@ -1,0 +1,41 @@
+from enum import Enum
+
+from fastapi import APIRouter
+from fastapi.responses import RedirectResponse, Response
+
+from src.services.fastapi.routes import riskgroups, strategies, vaults
+
+
+class Tags(Enum):
+    vaults = "Vaults"
+    strategies = "Strategies"
+    riskGroups = "Risk Groups"
+
+
+router = APIRouter()
+router.include_router(vaults.router, tags=[Tags.vaults], prefix="/api/vaults")
+router.include_router(
+    strategies.router, tags=[Tags.strategies], prefix="/api/strategies"
+)
+router.include_router(
+    riskgroups.router, tags=[Tags.riskGroups], prefix="/api/riskgroups"
+)
+
+
+@router.get("/", include_in_schema=False)
+def root():
+    message = """
+
+    Welcome to Yearn Data Analytics!
+
+    The current endpoint for the risk framework API is /api,
+    which will automatically redirect you to the API documentation page.
+
+    """
+    return Response(content=message, media_type="text/plain")
+
+
+@router.get("/api", include_in_schema=False)
+def redirect_api_docs():
+    """Redirect to the OpenAPI documentation"""
+    return RedirectResponse("/docs")

--- a/src/services/fastapi/routes/riskgroups.py
+++ b/src/services/fastapi/routes/riskgroups.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, HTTPException
+from sqlmodel import Session, select
+
+from src.models import RiskGroup, create_id
+from src.services.fastapi.db import engine
+
+router = APIRouter()
+
+
+@router.get("/")
+def get_all_risk_groups():
+    """Fetch all risk groups"""
+    with Session(engine) as session:
+        query = select(RiskGroup)
+        groups = session.exec(query).all()
+    return groups
+
+
+@router.get("/{chain_id}")
+def get_network_risk_groups(chain_id):
+    """Fetch risk groups for a specific chain"""
+    with Session(engine) as session:
+        query = select(RiskGroup).where(RiskGroup.network == chain_id)
+        groups = session.exec(query).all()
+    return groups
+
+
+@router.get("/{chain_id}/{group_id}")
+def get_risk_group(chain_id, group_id):
+    """Fetch a specific risk group"""
+    with Session(engine) as session:
+        group_id = create_id(group_id, chain_id)
+        group = session.get(RiskGroup, group_id)
+    if group is None:
+        raise HTTPException(status_code=404, detail="Group ID not found")
+    return group

--- a/src/services/fastapi/routes/strategies.py
+++ b/src/services/fastapi/routes/strategies.py
@@ -1,0 +1,38 @@
+import json
+
+from fastapi import APIRouter, HTTPException
+from sqlmodel import Session, select
+
+from src.models import Strategy, create_id
+from src.services.fastapi.db import engine
+
+router = APIRouter()
+
+
+@router.get("/")
+def get_all_strategies():
+    """Fetch strategy-level risk metrics for all available strategies"""
+    with Session(engine) as session:
+        query = select(Strategy)
+        strategies = session.exec(query).all()
+    return {strategy.address: json.loads(strategy.info) for strategy in strategies}
+
+
+@router.get("/{chain_id}")
+def get_network_strategies(chain_id):
+    """Fetch strategy-level risk metrics for a specific chain"""
+    with Session(engine) as session:
+        query = select(Strategy).where(Strategy.network == chain_id)
+        strategies = session.exec(query).all()
+    return {strategy.address: json.loads(strategy.info) for strategy in strategies}
+
+
+@router.get("/{chain_id}/{address}")
+def get_strategy(chain_id, address):
+    """Fetch strategy-level risk metrics for a specific strategy"""
+    with Session(engine) as session:
+        strategy_id = create_id(address, chain_id)
+        strategy = session.get(Strategy, strategy_id)
+    if strategy is None:
+        raise HTTPException(status_code=404, detail="Address not found")
+    return json.loads(strategy.info)

--- a/src/services/fastapi/routes/vaults.py
+++ b/src/services/fastapi/routes/vaults.py
@@ -1,0 +1,38 @@
+import json
+
+from fastapi import APIRouter, HTTPException
+from sqlmodel import Session, select
+
+from src.models import Vault, create_id
+from src.services.fastapi.db import engine
+
+router = APIRouter()
+
+
+@router.get("/")
+def get_all_vaults():
+    """Fetch vault-level risk metrics for all available vaults"""
+    with Session(engine) as session:
+        query = select(Vault)
+        vaults = session.exec(query).all()
+    return {vault.address: json.loads(vault.info) for vault in vaults}
+
+
+@router.get("/{chain_id}")
+def get_network_vaults(chain_id):
+    """Fetch vault-level risk metrics for a specific chain"""
+    with Session(engine) as session:
+        query = select(Vault).where(Vault.network == chain_id)
+        vaults = session.exec(query).all()
+    return {vault.address: json.loads(vault.info) for vault in vaults}
+
+
+@router.get("/{chain_id}/{address}")
+def get_vault(chain_id, address):
+    """Fetch vault-level risk metrics for a specific vault"""
+    with Session(engine) as session:
+        vault_id = create_id(address, chain_id)
+        vault = session.get(Vault, vault_id)
+    if vault is None:
+        raise HTTPException(status_code=404, detail="Address not found")
+    return json.loads(vault.info)


### PR DESCRIPTION
## Description

- Refactored routes into their respective logical routes
- FastAPI main app and app configurations are placed in `fastapi/main.py`
- Route management and configurations are place in `fastapi/routes/api.py`
- Database engine placed in `fastapi/db.py`

## Motivation and Context

- Better readability and maintainability

## How Has This Been Tested?

- Running FastAPI locally
