### PR TITLE
Feat/devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.9
+
+RUN pip install poetry && poetry config virtualenvs.create false
+
+# Comment out below if you don't need to use docker commands in devcontainer.
+# Please refer to https://github.com/microsoft/vscode-dev-containers/tree/main/containers/docker-from-docker-compose
+# Install Docker CE CLI
+RUN apt-get update \
+    && apt-get install -y apt-transport-https ca-certificates curl gnupg2 lsb-release \
+    && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | apt-key add - 2>/dev/null \
+    && echo "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y docker-ce-cli
+
+# Install Docker Compose
+RUN export LATEST_COMPOSE_VERSION=$(curl -sSL "https://api.github.com/repos/docker/compose/releases/latest" | grep -o -P '(?<="tag_name": ").+(?=")') \
+    && curl -sSL "https://github.com/docker/compose/releases/download/${LATEST_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
+    && chmod +x /usr/local/bin/docker-compose
+
+RUN apt-get install -y iputils-ping net-tools vim

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.238.0/containers/docker-existing-docker-compose
+// If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
+{
+	"name": "YDA",
+	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
+	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+	"dockerComposeFile": [
+		"../docker-compose.yml",
+		"docker-compose.yml"
+	],
+	// The 'service' property is the name of the service for the container that VS Code should
+	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+	"service": "develop",
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
+	"workspaceFolder": "/workspace",
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"extensions": [
+				"ms-python.python"
+			]
+		}
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	// "shutdownAction": "none",
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	"postCreateCommand": "bash ./.devcontainer/postCreateCommand.sh"
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '2'
+services:
+  # Update this to the name of the service you want to work with in your docker-compose.yml file
+  develop:
+    # If you want add a non-root user to your Dockerfile, you can use the "remoteUser"
+    # property in devcontainer.json to cause VS Code its sub-processes (terminals, tasks, 
+    # debugging) to execute as the user. Uncomment the next line if you want the entire 
+    # container to run as this user instead. Note that, on Linux, you may need to 
+    # ensure the UID and GID of the container user you create matches your local user. 
+    # See https://aka.ms/vscode-remote/containers/non-root for details.
+    #
+    # user: vscode
+
+    # Uncomment if you want to override the service's Dockerfile to one in the .devcontainer 
+    # folder. Note that the path of the Dockerfile and context is relative to the *primary* 
+    # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
+    # array). The sample below assumes your primary file is in the root of your project.
+    #
+    build:
+      context: .
+      dockerfile: .devcontainer/Dockerfile
+
+    hostname: yda-dev
+
+    env_file: ./.env
+
+    volumes:
+      # Update this to wherever you want VS Code to mount the folder of your project
+      - .:/workspace:cached
+
+      # Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker-compose for details.
+      - /var/run/docker.sock:/var/run/docker.sock 
+
+    # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
+    # cap_add:
+    #   - SYS_PTRACE
+    # security_opt:
+    #   - seccomp:unconfined
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: /bin/sh -c "while sleep 1000; do :; done"
+ 

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,1 +1,2 @@
 poetry install
+pre-commit install

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,2 +1,1 @@
 poetry install
-pytest

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,2 @@
+poetry install
+pytest

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ __pycache__/
 
 env/
 venv/
+.venv/
 
 *.db
 *.sqlite3

--- a/README.md
+++ b/README.md
@@ -66,3 +66,12 @@ To run the API locally at port 80:
 docker-compose up --build
 ```
 Auto-generated docs can be seen at [localhost/docs](http://localhost/docs)
+
+### DevContainer
+
+If you're using VSCode, you can use DevContainer to setup all the required dependencies (almost) automatically.
+**But you first need to set up `./.env` file though.**
+If you have filled out `./.env`, open cloned dir in VSC and just press `Reopen in Container` button on the right bottom side.  
+<img width="459" alt="image" src="https://user-images.githubusercontent.com/103443013/173222631-fa280003-24e2-4f49-85da-dc1d88bc2633.png">  
+Or use command palette to search `Remote-Containers: Reopen in Container`.
+Then VSC will do the rest. pytest in the integrated terminal after the build process. You'll pass all tests if your DevContainer has no problem and `.env` is set properly.

--- a/tests/risk_framework/test_analysis.py
+++ b/tests/risk_framework/test_analysis.py
@@ -1,5 +1,6 @@
-import os
 import json
+import os
+
 import pytest
 from dotenv import load_dotenv
 
@@ -7,7 +8,7 @@ from src.risk_framework import RiskAnalysis
 
 from ..constants import CRV3_VAULT, CRV_VAULT, STRAT1, STRAT2, STRAT3, USDC_VAULT
 
-BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+BASE_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "..", "..")
 load_dotenv(dotenv_path=os.path.join(BASE_DIR, ".env"))
 
 

--- a/tests/risk_framework/test_analysis.py
+++ b/tests/risk_framework/test_analysis.py
@@ -1,5 +1,5 @@
+import os
 import json
-
 import pytest
 from dotenv import load_dotenv
 
@@ -7,7 +7,8 @@ from src.risk_framework import RiskAnalysis
 
 from ..constants import CRV3_VAULT, CRV_VAULT, STRAT1, STRAT2, STRAT3, USDC_VAULT
 
-load_dotenv()
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+load_dotenv(dotenv_path=os.path.join(BASE_DIR, ".env"))
 
 
 risk = RiskAnalysis()

--- a/tests/utils/test_web3.py
+++ b/tests/utils/test_web3.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from dotenv import load_dotenv
 
@@ -11,8 +12,8 @@ from ..constants import (
     USDC_VAULT_ADDRESS,
     WFTM_VAULT_ADDRESS,
 )
-
-load_dotenv()
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+load_dotenv(dotenv_path=os.path.join(BASE_DIR, ".env"))
 
 addresses = [USDC_VAULT_ADDRESS, WFTM_VAULT_ADDRESS, CRV3_VAULT_ADDRESS]
 usdc = [

--- a/tests/utils/test_web3.py
+++ b/tests/utils/test_web3.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 from dotenv import load_dotenv
 
@@ -12,7 +13,8 @@ from ..constants import (
     USDC_VAULT_ADDRESS,
     WFTM_VAULT_ADDRESS,
 )
-BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+
+BASE_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "..", "..")
 load_dotenv(dotenv_path=os.path.join(BASE_DIR, ".env"))
 
 addresses = [USDC_VAULT_ADDRESS, WFTM_VAULT_ADDRESS, CRV3_VAULT_ADDRESS]

--- a/tests/yearn/test_strategies.py
+++ b/tests/yearn/test_strategies.py
@@ -1,9 +1,11 @@
 import os
+
 import pytest
 from dotenv import load_dotenv
 
 from ..constants import DAYS, STRAT1, STRAT2, STRAT3
-BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+
+BASE_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "..", "..")
 load_dotenv(dotenv_path=os.path.join(BASE_DIR, ".env"))
 
 strategies = [

--- a/tests/yearn/test_strategies.py
+++ b/tests/yearn/test_strategies.py
@@ -1,9 +1,10 @@
+import os
 import pytest
 from dotenv import load_dotenv
 
 from ..constants import DAYS, STRAT1, STRAT2, STRAT3
-
-load_dotenv()
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+load_dotenv(dotenv_path=os.path.join(BASE_DIR, ".env"))
 
 strategies = [
     STRAT1,

--- a/tests/yearn/test_subgraph.py
+++ b/tests/yearn/test_subgraph.py
@@ -1,11 +1,13 @@
 import os
+
 import pytest
 from dotenv import load_dotenv
 
 from src.yearn import Subgraph
 
 from ..constants import CRV3_VAULT, CRV_VAULT, USDC_VAULT
-BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+
+BASE_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "..", "..")
 load_dotenv(dotenv_path=os.path.join(BASE_DIR, ".env"))
 
 vaults = [USDC_VAULT, CRV_VAULT, CRV3_VAULT]

--- a/tests/yearn/test_subgraph.py
+++ b/tests/yearn/test_subgraph.py
@@ -1,11 +1,12 @@
+import os
 import pytest
 from dotenv import load_dotenv
 
 from src.yearn import Subgraph
 
 from ..constants import CRV3_VAULT, CRV_VAULT, USDC_VAULT
-
-load_dotenv()
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+load_dotenv(dotenv_path=os.path.join(BASE_DIR, ".env"))
 
 vaults = [USDC_VAULT, CRV_VAULT, CRV3_VAULT]
 

--- a/tests/yearn/test_vaults.py
+++ b/tests/yearn/test_vaults.py
@@ -1,9 +1,10 @@
+import os
 import pytest
 from dotenv import load_dotenv
 
 from ..constants import CRV3_VAULT, CRV_VAULT, USDC_VAULT
-
-load_dotenv()
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+load_dotenv(dotenv_path=os.path.join(BASE_DIR, ".env"))
 
 vaults = [USDC_VAULT, CRV_VAULT, CRV3_VAULT]
 

--- a/tests/yearn/test_vaults.py
+++ b/tests/yearn/test_vaults.py
@@ -1,9 +1,11 @@
 import os
+
 import pytest
 from dotenv import load_dotenv
 
 from ..constants import CRV3_VAULT, CRV_VAULT, USDC_VAULT
-BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+
+BASE_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "..", "..")
 load_dotenv(dotenv_path=os.path.join(BASE_DIR, ".env"))
 
 vaults = [USDC_VAULT, CRV_VAULT, CRV3_VAULT]

--- a/tests/yearn/test_yearn.py
+++ b/tests/yearn/test_yearn.py
@@ -1,9 +1,11 @@
 import os
+
 import pytest
 from dotenv import load_dotenv
 
 from ..constants import YEARN_ARBITRUM, YEARN_FANTOM, YEARN_MAINNET
-BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+
+BASE_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "..", "..")
 load_dotenv(dotenv_path=os.path.join(BASE_DIR, ".env"))
 
 yearn_chains = [

--- a/tests/yearn/test_yearn.py
+++ b/tests/yearn/test_yearn.py
@@ -1,9 +1,10 @@
+import os
 import pytest
 from dotenv import load_dotenv
 
 from ..constants import YEARN_ARBITRUM, YEARN_FANTOM, YEARN_MAINNET
-
-load_dotenv()
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+load_dotenv(dotenv_path=os.path.join(BASE_DIR, ".env"))
 
 yearn_chains = [
     YEARN_MAINNET,


### PR DESCRIPTION
# DevContainer Configurations
## Purpose
Contributors who're using docker container for development or just using VSCode can easily setup dev environment.
## Usage
updated on README.md as well.
### DevContainer

 If you're using VSCode, you can use DevContainer to setup all the required dependencies (almost) automatically.
 **But you first need to set up `./.env` file though.**
 If you have filled out `./.env`, open cloned dir in VSC and just press `Reopen in Container` button on the right bottom side.  
 <img width="459" alt="image" src="https://user-images.githubusercontent.com/103443013/173222631-fa280003-24e2-4f49-85da-dc1d88bc2633.png">  
 Or use command palette to search `Remote-Containers: Reopen in Container`.
 Then VSC will do the rest. pytest in the integrated terminal after the build process. You'll pass all tests if your DevContainer has no problem and `.env` is set properly.