### PR TITLE
fix: Update IDLE nameLike

### DIFF
--- a/src/risk_framework/risks.json
+++ b/src/risk_framework/risks.json
@@ -90,7 +90,7 @@
 		"complexityScore": 2,
 		"teamKnowledgeScore": 4,
 		"criteria": {
-			"nameLike": ["idle"],
+			"nameLike": ["StrategyIdleV2", "idle"],
 			"strategies": [],
 			"exclude": []
 		}


### PR DESCRIPTION
## Description

- Updated idle group's `nameLike` from `["idle"]` to `["StrategyIdleV2", "idle"]` for Ethereum

## Related Issue

- Fixes #48

